### PR TITLE
Add support for go_library import path

### DIFF
--- a/domain/wollemi/service_format.go
+++ b/domain/wollemi/service_format.go
@@ -171,10 +171,15 @@ func (this *Service) GoFormat(rewrite bool, paths []string) error {
 						target += ":" + name
 					}
 
-					internal[path] = "//" + target
+					importPath := rule.AttrString("import_path")
+					if importPath != "" {
+						external[importPath] = append(external[path], "//"+target)
+					} else {
+						internal[path] = "//" + target
 
-					if rule.Kind() == "go_copy" {
-						genfiles[path+".cp.go"] = target
+						if rule.Kind() == "go_copy" {
+							genfiles[path+".cp.go"] = target
+						}
 					}
 				case "go_get", "go_get_with_sources":
 					get := strings.TrimSuffix(rule.AttrString("get"), "/...")


### PR DESCRIPTION
This is a draft for adding support for the new `import_path` attribute in the official `go_library` rule in https://github.com/thought-machine/please/pull/1158