### PR TITLE
Set deps only when there are at least 1 dependency

### DIFF
--- a/domain/wollemi/service_format.go
+++ b/domain/wollemi/service_format.go
@@ -641,7 +641,9 @@ func (this *Service) GoFormat(rewrite bool, paths []string) error {
 							return iPath < jPath
 						})
 
-						rule.SetAttr("deps", please.Strings(deps...))
+						if len(deps) > 0 {
+							rule.SetAttr("deps", please.Strings(deps...))
+						}
 
 						if isGeneratedRule {
 							dir.Build.SetRule(rule)


### PR DESCRIPTION
Seems to avoid
```
deps = [],
```
