### PR TITLE
Handle empty install list and ... wildcard in go_module() installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 plz-out
 
 *.mg.go
+.idea

--- a/domain/wollemi/service_format.go
+++ b/domain/wollemi/service_format.go
@@ -195,8 +195,14 @@ func (this *Service) GoFormat(config wollemi.Config, paths []string) error {
 						Path: dir.Path,
 					}
 
-					for _, install := range rule.AttrStrings("install") {
-						install = strings.TrimSuffix(install, "/...")
+
+					install := rule.AttrStrings("install")
+					if len(install) == 0 {
+						install = []string{"."} // Empty install list installs the root package
+					}
+
+					for _, install := range install {
+						install = filepath.Clean(strings.TrimSuffix(install, "..."))
 						path := module
 
 						if install != "." {


### PR DESCRIPTION
`go_module()` installs the root module for an empty install list, and the `...` wildcard wasn't being handled for the root package correctly. 

Really Please should make it easier for you to ask these sorts of questions. We're working on it. 